### PR TITLE
add pod antiaffinity for nsq-operator deployment

### DIFF
--- a/kubernetes/nsq-operator-deployment.yaml
+++ b/kubernetes/nsq-operator-deployment.yaml
@@ -13,12 +13,24 @@ spec:
       labels:
         app: nsq-operator
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - nsq-operator
+                topologyKey: "kubernetes.io/hostname"
       containers:
         - name: nsq-operator
-          image: dockerops123/nsq-operator:0.2.0
+          image: dockerops123/nsq-operator:0.3.0
           imagePullPolicy: Always
           ports:
-            - name: http-metrics
+            - name: http
               containerPort: 3080
           readinessProbe:
             httpGet:
@@ -36,8 +48,8 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: "0.1"
-              memory: "500Mi"
+              cpu: "2"
+              memory: "2Gi"
             limits:
-              cpu: "0.1"
-              memory: "500Mi"
+              cpu: "2"
+              memory: "2Gi"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR adds pod antiaffinity config to nsq-operator deployment.
