### PR TITLE
add log volume support

### DIFF
--- a/images/scripts/start_nsqadmin.sh
+++ b/images/scripts/start_nsqadmin.sh
@@ -58,8 +58,12 @@ else
   exit 1
 fi
 
-LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/nsqadmin/$(hostname)"}
+if [[ -z "${NSQ_CLUSTER}" ]]; then
+  echo "NSQ_CLUSTER environment variable is unset or empty"
+  exit 1
+fi
 
+LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/$(hostname)"}
 mkdir -p ${LOG_DIR}
 
 nsqadmin ${NSQADMIN_COMMAND_ARGUMENTS} --lookupd-http-address=${NSQADMIN_LOOKUPD_HTTP_ADDRESS} 2>&1 | /usr/local/bin/cronolog_alpine ${LOG_DIR}/log.%Y-%m-%d_%H &

--- a/images/scripts/start_nsqd.sh
+++ b/images/scripts/start_nsqd.sh
@@ -58,8 +58,12 @@ else
   exit 1
 fi
 
-LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/nsqd/$(hostname)"}
+if [[ -z "${NSQ_CLUSTER}" ]]; then
+  echo "NSQ_CLUSTER environment variable is unset or empty"
+  exit 1
+fi
 
+LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/$(hostname)"}
 mkdir -p ${LOG_DIR}
 
 nsqd ${NSQD_COMMAND_ARGUMENTS} --lookupd-tcp-address=${NSQD_LOOKUPD_TCP_ADDRESS} -statsd-address=${NODE_IP}:8125 2>&1 | /usr/local/bin/cronolog_alpine ${LOG_DIR}/log.%Y-%m-%d_%H &

--- a/images/scripts/start_nsqlookupd.sh
+++ b/images/scripts/start_nsqlookupd.sh
@@ -58,8 +58,12 @@ else
   exit 1
 fi
 
-LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/nsqlookupd/$(hostname)"}
+if [[ -z "${NSQ_CLUSTER}" ]]; then
+  echo "NSQ_CLUSTER environment variable is unset or empty"
+  exit 1
+fi
 
+LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/$(hostname)"}
 mkdir -p ${LOG_DIR}
 
 nsqlookupd ${NSQLOOKUPD_COMMAND_ARGUMENTS} 2>&1 | /usr/local/bin/cronolog_alpine ${LOG_DIR}/log.%Y-%m-%d_%H &

--- a/manifests/v1alpha1/nsqadmin.yaml
+++ b/manifests/v1alpha1/nsqadmin.yaml
@@ -26,3 +26,5 @@ spec:
               maximum: 4
             image:
               type: string
+            logMappingDir:
+              type: string

--- a/manifests/v1alpha1/nsqd.yaml
+++ b/manifests/v1alpha1/nsqd.yaml
@@ -28,3 +28,5 @@ spec:
               type: string
             storageClassName:
               type: string
+            logMappingDir:
+              type: string

--- a/manifests/v1alpha1/nsqlookupd.yaml
+++ b/manifests/v1alpha1/nsqlookupd.yaml
@@ -26,3 +26,5 @@ spec:
               maximum: 16
             image:
               type: string
+            logMappingDir:
+              type: string

--- a/manifests/v1alpha1/test_data/nsqadmin.yaml
+++ b/manifests/v1alpha1/test_data/nsqadmin.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   replicas: 2
   image: dockerops123/nsqadmin:1.1.0
+  logMappingDir: /var/log/nsqadmin/

--- a/manifests/v1alpha1/test_data/nsqd.yaml
+++ b/manifests/v1alpha1/test_data/nsqd.yaml
@@ -6,3 +6,4 @@ spec:
   replicas: 2
   image: dockerops123/nsqd:1.1.0
   storageClassName: standard
+  logMappingDir: /var/log/nsqd/

--- a/manifests/v1alpha1/test_data/nsqlookupd.yaml
+++ b/manifests/v1alpha1/test_data/nsqlookupd.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   replicas: 2
   image: dockerops123/nsqlookupd:1.1.0
+  logMappingDir: /var/log/nsqlookupd/

--- a/pkg/apis/nsqio/v1alpha1/types.go
+++ b/pkg/apis/nsqio/v1alpha1/types.go
@@ -37,6 +37,7 @@ type NsqdSpec struct {
 	Image            string `json:"image"`
 	Replicas         *int32 `json:"replicas"`
 	StorageClassName string `json:"storageClassName"`
+	LogMappingDir    string `json:"logMappingDir"`
 }
 
 // NsqdStatus is the status for a Nsqd resource
@@ -68,8 +69,9 @@ type NsqLookupd struct {
 
 // NsqLookupdSpec is the spec for a NsqLookupd resource
 type NsqLookupdSpec struct {
-	Image    string `json:"image"`
-	Replicas *int32 `json:"replicas"`
+	Image         string `json:"image"`
+	Replicas      *int32 `json:"replicas"`
+	LogMappingDir string `json:"logMappingDir"`
 }
 
 // NsqLookupdStatus is the status for a NsqLookupd resource
@@ -101,8 +103,9 @@ type NsqAdmin struct {
 
 // NsqAdminSpec is the spec for a NsqAdmin resource
 type NsqAdminSpec struct {
-	Image    string `json:"image"`
-	Replicas *int32 `json:"replicas"`
+	Image         string `json:"image"`
+	Replicas      *int32 `json:"replicas"`
+	LogMappingDir string `json:"logMappingDir"`
 }
 
 // NsqAdminStatus is the status for a NsqAdmin resource

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -15,8 +15,23 @@ limitations under the License.
 */
 package common
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func AssembleNsqLookupdAddresses(nsqLookupdAddressed []string) string {
 	return strings.Join(nsqLookupdAddressed, ",")
+}
+
+func NsqdLogMountPath(cluster string) string {
+	return fmt.Sprintf("/var/log/%s/", cluster)
+}
+
+func NsqLookupdLogMountPath(cluster string) string {
+	return fmt.Sprintf("/var/log/%s/", cluster)
+}
+
+func NsqAdminLogMountPath(cluster string) string {
+	return fmt.Sprintf("/var/log/%s/", cluster)
 }

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -32,6 +32,8 @@ const (
 	// Cluster environment Name
 	ClusterNameEnv = "NSQ_CLUSTER"
 
+	LogVolumeName = "log"
+
 	NsqConfigMapMountPath = "/etc/nsq"
 	NsqdDataMountPath     = "/data"
 

--- a/pkg/controller/nsqadmin.go
+++ b/pkg/controller/nsqadmin.go
@@ -522,6 +522,10 @@ func (nac *NsqAdminController) newDeployment(na *nsqv1alpha1.NsqAdmin, configMap
 									Name:      common.NsqAdminConfigMapName(na.Name),
 									MountPath: constant.NsqConfigMapMountPath,
 								},
+								{
+									Name:      constant.LogVolumeName,
+									MountPath: common.NsqAdminLogMountPath(na.Name),
+								},
 							},
 							ImagePullPolicy: corev1.PullAlways,
 							Resources: corev1.ResourceRequirements{
@@ -578,6 +582,14 @@ func (nac *NsqAdminController) newDeployment(na *nsqv1alpha1.NsqAdmin, configMap
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: common.NsqAdminConfigMapName(na.Name),
 									},
+								},
+							},
+						},
+						{
+							Name: constant.LogVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: na.Spec.LogMappingDir,
 								},
 							},
 						},

--- a/pkg/controller/nsqd.go
+++ b/pkg/controller/nsqd.go
@@ -540,6 +540,10 @@ func (ndc *NsqdController) newStatefulSet(nd *nsqv1alpha1.Nsqd, configMapHash st
 									Name:      common.NsqdVolumeClaimTemplatesName(nd.Name),
 									MountPath: constant.NsqdDataMountPath,
 								},
+								{
+									Name:      constant.LogVolumeName,
+									MountPath: common.NsqdLogMountPath(nd.Name),
+								},
 							},
 							ImagePullPolicy: corev1.PullAlways,
 							Resources: corev1.ResourceRequirements{
@@ -590,6 +594,14 @@ func (ndc *NsqdController) newStatefulSet(nd *nsqv1alpha1.Nsqd, configMapHash st
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: common.NsqdConfigMapName(nd.Name),
 									},
+								},
+							},
+						},
+						{
+							Name: constant.LogVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: nd.Spec.LogMappingDir,
 								},
 							},
 						},

--- a/pkg/controller/nsqlookupd.go
+++ b/pkg/controller/nsqlookupd.go
@@ -635,6 +635,10 @@ func (nlc *NsqLookupdController) newDeployment(nl *nsqv1alpha1.NsqLookupd, confi
 									Name:      common.NsqLookupdConfigMapName(nl.Name),
 									MountPath: constant.NsqConfigMapMountPath,
 								},
+								{
+									Name:      constant.LogVolumeName,
+									MountPath: common.NsqLookupdLogMountPath(nl.Name),
+								},
 							},
 							ImagePullPolicy: corev1.PullAlways,
 							Resources: corev1.ResourceRequirements{
@@ -691,6 +695,14 @@ func (nlc *NsqLookupdController) newDeployment(nl *nsqv1alpha1.NsqLookupd, confi
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: common.NsqLookupdConfigMapName(nl.Name),
 									},
+								},
+							},
+						},
+						{
+							Name: constant.LogVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: nl.Spec.LogMappingDir,
 								},
 							},
 						},

--- a/pkg/sdk/examples/create_cluster.go
+++ b/pkg/sdk/examples/create_cluster.go
@@ -51,16 +51,19 @@ func main() {
 		Image:            "dockerops123/nsqd:1.1.0",
 		Replicas:         &nsqdReplicas,
 		StorageClassName: "standard",
+		LogMappingDir:    "/var/log/",
 	}
 
 	nls := v1alpha1.NsqLookupdSpec{
-		Image:    "dockerops123/nsqlookupd:1.1.0",
-		Replicas: &nsqLookupdReplicas,
+		Image:         "dockerops123/nsqlookupd:1.1.0",
+		Replicas:      &nsqLookupdReplicas,
+		LogMappingDir: "/var/log/",
 	}
 
 	nas := v1alpha1.NsqAdminSpec{
-		Image:    "dockerops123/nsqadmin:1.1.0",
-		Replicas: &nsqAdminReplicas,
+		Image:         "dockerops123/nsqadmin:1.1.0",
+		Replicas:      &nsqAdminReplicas,
+		LogMappingDir: "/var/log/",
 	}
 
 	nr := types.NewNsqCreateRequest(name, namespace, messageAvgSize, nds, nls, nas)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR adds `logMappingDir` field to nsqd/nsqlookupd/nsqadmin components to make them customize the mapping log dir.
