### PR TITLE
enhance sdk v1alpha1

### DIFF
--- a/images/scripts/start_nsqd.sh
+++ b/images/scripts/start_nsqd.sh
@@ -66,6 +66,6 @@ fi
 LOG_DIR=${LOG_DIR:-"/var/log/${NSQ_CLUSTER}/$(hostname)"}
 mkdir -p ${LOG_DIR}
 
-nsqd ${NSQD_COMMAND_ARGUMENTS} --lookupd-tcp-address=${NSQD_LOOKUPD_TCP_ADDRESS} -statsd-address=${NODE_IP}:8125 2>&1 | /usr/local/bin/cronolog_alpine ${LOG_DIR}/log.%Y-%m-%d_%H &
+nsqd ${NSQD_COMMAND_ARGUMENTS} -lookupd-tcp-address=${NSQD_LOOKUPD_TCP_ADDRESS} -broadcast-address=${POD_IP} -statsd-address=${NODE_IP}:8125 2>&1 | /usr/local/bin/cronolog_alpine ${LOG_DIR}/log.%Y-%m-%d_%H &
 
 wait

--- a/pkg/controller/nsqd.go
+++ b/pkg/controller/nsqd.go
@@ -568,6 +568,14 @@ func (ndc *NsqdController) newStatefulSet(nd *nsqv1alpha1.Nsqd, configMapHash st
 									},
 								},
 								{
+									Name: "POD_IP",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "status.podIP",
+										},
+									},
+								},
+								{
 									Name:  constant.ClusterNameEnv,
 									Value: nd.Name,
 								},

--- a/pkg/sdk/v1alpha1/common/common.go
+++ b/pkg/sdk/v1alpha1/common/common.go
@@ -34,7 +34,7 @@ func AssembleNsqLookupdConfigMap(nr *types.NsqCreateRequest) *corev1.ConfigMap {
 			Namespace: nr.Namespace,
 		},
 		Data: map[string]string{
-			"nsqlookupd": fmt.Sprintf(`%s="--http-address=0.0.0.0:%v --tcp-address=0.0.0.0:%v\n"`,
+			"nsqlookupd": fmt.Sprintf("%s=\"--http-address=0.0.0.0:%v --tcp-address=0.0.0.0:%v\n\"",
 				constant.NsqLookupdCommandArguments, constant.NsqLookupdHttpPort, constant.NsqLookupdTcpPort),
 		},
 	}
@@ -58,14 +58,14 @@ func assembleNsqdCommandArguments(nr *types.NsqCreateRequest) string {
 	return fmt.Sprintf("-statsd-interval=%v "+
 		"-statsd-mem-stats=%v "+
 		"-statsd-prefix=nsq_cluster_%s.%s "+
-		"--http-address=0.0.0.0:%v "+
-		"--tcp-address=0.0.0.0:%v "+
-		"--max-req-timeout=%v "+
-		"--mem-queue-size=%v "+
-		"--max-msg-size=%v "+
-		"--max-body-size=%v "+
-		"--sync-every=%v "+
-		"--sync-timeout=%v "+
+		"-http-address=0.0.0.0:%v "+
+		"-tcp-address=0.0.0.0:%v "+
+		"-max-req-timeout=%v "+
+		"-mem-queue-size=%v "+
+		"-max-msg-size=%v "+
+		"-max-body-size=%v "+
+		"-sync-every=%v "+
+		"-sync-timeout=%v "+
 		"-data-path=%v", *nr.NsqdCommandStatsdInterval, *nr.NsqdCommandStatsdMemStats, nr.Name, nr.Name,
 		constant.NsqdHttpPort, constant.NsqdTcpPort,
 		*nr.NsqdCommandMaxRequeueTimeout, *nr.TopicMemoryQueueSize, *nr.NsqdCommandMaxMsgSize,

--- a/pkg/sdk/v1alpha1/nsq.go
+++ b/pkg/sdk/v1alpha1/nsq.go
@@ -210,7 +210,7 @@ func CreateCluster(kubeClient *kubernetes.Clientset, nsqClient *versioned.Client
 
 	var addresses []string
 	for _, pod := range podList.Items {
-		addresses = append(addresses, fmt.Sprintf("%s:%v", pod.Status.PodIP, constant.NsqLookupdHttpPort))
+		addresses = append(addresses, fmt.Sprintf("%s:%v", pod.Status.PodIP, constant.NsqLookupdTcpPort))
 	}
 
 	nsqdCM := common.AssembleNsqdConfigMap(nr, addresses)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR will enhance sdk v1alpha1 with:
* correct nsqd's command line argument for nsqlookupd tcp address port
* fix nsqlookupd's configmap trailing `\n` escape error
* fix nsqd's `-broadcast-address` to pod ip
* update nsqd's configmap when nsqlookupd changes
