### PR TITLE
refactor nsqd crd

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ some feedback.
 * Scale nsqd/nsqlookupd/nsqadmin components separately
 * Update nsqd/nsqlookupd/nsqadmin image separately
 * Adjust nsqd command line arguments
-* Adjust nsqd pods memory resource according to average message size, memory queue size, memory oversale percent and channel count
+* Adjust nsqd pods memory resource according to average message size, memory queue size, memory overbooking percent and channel count
 * Log Management. 
   * Rotate log by [logrotate](https://linux.die.net/man/8/logrotate) hourly
   * Mount log directory to a dedicated host machine directory in nsqd/nsqlookupd/nsqadmin spec

--- a/manifests/v1alpha1/nsqd.yaml
+++ b/manifests/v1alpha1/nsqd.yaml
@@ -22,7 +22,7 @@ spec:
           properties:
             replicas:
               type: integer
-              minimum: 1
+              minimum: 2
               maximum: 2048
             image:
               type: string
@@ -34,15 +34,15 @@ spec:
               type: integer
               minimum: 1
               maximum: 10485760   # 10Mi
-            MemoryOverSalePercent:
+            MemoryOverBookingPercent:
               type: integer
-              minimum: 1
+              minimum: 0
               maximum: 100
             memoryQueueSize:
               type: integer
-              minimum: 1
+              minimum: 0
               maximum: 10000
             channelCount:
               type: integer
               minimum: 0
-              maximum: 1024
+              maximum: 2048

--- a/manifests/v1alpha1/test_data/nsqd.yaml
+++ b/manifests/v1alpha1/test_data/nsqd.yaml
@@ -9,5 +9,5 @@ spec:
   logMappingDir: /var/log/test
   messageAvgSize: 1048576   # 1Mi
   memoryQueueSize: 10000
-  memoryOverSalePercent: 50
+  memoryOverBookingPercent: 50
   channelCount: 0

--- a/pkg/apis/nsqio/v1alpha1/types.go
+++ b/pkg/apis/nsqio/v1alpha1/types.go
@@ -34,23 +34,23 @@ type Nsqd struct {
 
 // NsqdSpec is the spec for a Nsqd resource
 type NsqdSpec struct {
-	Image                 string `json:"image"`
-	Replicas              int32  `json:"replicas"`
-	StorageClassName      string `json:"storageClassName"`
-	LogMappingDir         string `json:"logMappingDir"`
-	MessageAvgSize        int32  `json:"messageAvgSize"`
-	MemoryOverSalePercent int32  `json:"memoryOverSalePercent"`
-	MemoryQueueSize       int32  `json:"memoryQueueSize"`
-	ChannelCount          int32  `json:"channelCount"`
+	Image                    string `json:"image"`
+	Replicas                 int32  `json:"replicas"`
+	StorageClassName         string `json:"storageClassName"`
+	LogMappingDir            string `json:"logMappingDir"`
+	MessageAvgSize           int32  `json:"messageAvgSize"`
+	MemoryOverBookingPercent int32  `json:"memoryOverBookingPercent"`
+	MemoryQueueSize          int32  `json:"memoryQueueSize"`
+	ChannelCount             int32  `json:"channelCount"`
 }
 
 // NsqdStatus is the status for a Nsqd resource
 type NsqdStatus struct {
-	AvailableReplicas     int32 `json:"availableReplicas"`
-	MessageAvgSize        int32 `json:"messageAvgSize"`
-	MemoryOverSalePercent int32 `json:"memoryOverSalePercent"`
-	MemoryQueueSize       int32 `json:"memoryQueueSize"`
-	ChannelCount          int32 `json:"channelCount"`
+	AvailableReplicas        int32 `json:"availableReplicas"`
+	MessageAvgSize           int32 `json:"messageAvgSize"`
+	MemoryOverBookingPercent int32 `json:"memoryOverBookingPercent"`
+	MemoryQueueSize          int32 `json:"memoryQueueSize"`
+	ChannelCount             int32 `json:"channelCount"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/nsqd.go
+++ b/pkg/controller/nsqd.go
@@ -561,7 +561,7 @@ func (ndc *NsqdController) syncHandler(key string) error {
 
 	}
 
-	if !(nd.Spec.MemoryOverSalePercent == nd.Status.MemoryOverSalePercent &&
+	if !(nd.Spec.MemoryOverBookingPercent == nd.Status.MemoryOverBookingPercent &&
 		nd.Spec.MessageAvgSize == nd.Status.MessageAvgSize &&
 		nd.Spec.MemoryQueueSize == nd.Status.MemoryQueueSize &&
 		nd.Spec.ChannelCount == nd.Status.ChannelCount) {
@@ -667,7 +667,7 @@ func (ndc *NsqdController) updateNsqdStatus(nd *nsqv1alpha1.Nsqd, statefulSet *a
 		// Or create a copy manually for better performance
 		ndCopy := ndOld.DeepCopy()
 		ndCopy.Status.AvailableReplicas = nd.Spec.Replicas
-		ndCopy.Status.MemoryOverSalePercent = nd.Spec.MemoryOverSalePercent
+		ndCopy.Status.MemoryOverBookingPercent = nd.Spec.MemoryOverBookingPercent
 		ndCopy.Status.MessageAvgSize = nd.Spec.MessageAvgSize
 		ndCopy.Status.MemoryQueueSize = nd.Spec.MemoryQueueSize
 		ndCopy.Status.ChannelCount = nd.Spec.ChannelCount
@@ -805,7 +805,7 @@ func (ndc *NsqdController) computeNsqdMemoryResource(nd *nsqv1alpha1.Nsqd) (requ
 	singleMemUsage := int64(nd.Spec.MessageAvgSize) * int64(nd.Spec.MemoryQueueSize)
 
 	standardTotalMem := count * singleMemUsage
-	AdjustedTotalMem := float64(standardTotalMem) * (1 + float64(nd.Spec.MemoryOverSalePercent)/100.0)
+	AdjustedTotalMem := float64(standardTotalMem) * (1 + float64(nd.Spec.MemoryOverBookingPercent)/100.0)
 
 	request = resource.MustParse(fmt.Sprintf("%vMi", int64(math.Ceil(AdjustedTotalMem/1024.0/1024.0))))
 	limit = request

--- a/pkg/controller/nsqd_test.go
+++ b/pkg/controller/nsqd_test.go
@@ -24,40 +24,40 @@ import (
 
 func TestComputeNsqdMemoryResource(t *testing.T) {
 	cases := []struct {
-		Desc                  string
-		MessageAvgSize        int32
-		MemoryOverSalePercent int32
-		MemoryQueueSize       int32
-		ChannelCount          int32
-		WantedRequest         string
-		WantedLimit           string
+		Desc                     string
+		MessageAvgSize           int32
+		MemoryOverBookingPercent int32
+		MemoryQueueSize          int32
+		ChannelCount             int32
+		WantedRequest            string
+		WantedLimit              string
 	}{
 		{
-			Desc:                  "topic 1, channel 0",
-			MessageAvgSize:        123,
-			MemoryQueueSize:       10000,
-			MemoryOverSalePercent: 50,
-			ChannelCount:          0,
-			WantedRequest:         "2Mi",
-			WantedLimit:           "2Mi",
+			Desc:                     "topic 1, channel 0",
+			MessageAvgSize:           123,
+			MemoryQueueSize:          10000,
+			MemoryOverBookingPercent: 50,
+			ChannelCount:             0,
+			WantedRequest:            "2Mi",
+			WantedLimit:              "2Mi",
 		},
 		{
-			Desc:                  "topic 1, channel 1",
-			MessageAvgSize:        234,
-			MemoryQueueSize:       567,
-			MemoryOverSalePercent: 30,
-			ChannelCount:          1,
-			WantedRequest:         "1Mi",
-			WantedLimit:           "1Mi",
+			Desc:                     "topic 1, channel 1",
+			MessageAvgSize:           234,
+			MemoryQueueSize:          567,
+			MemoryOverBookingPercent: 30,
+			ChannelCount:             1,
+			WantedRequest:            "1Mi",
+			WantedLimit:              "1Mi",
 		},
 		{
-			Desc:                  "topic 1, channel 1024(Overflow int32)",
-			MessageAvgSize:        1024,
-			MemoryQueueSize:       10000,
-			MemoryOverSalePercent: 100,
-			ChannelCount:          1024,
-			WantedRequest:         "20020Mi",
-			WantedLimit:           "20020Mi",
+			Desc:                     "topic 1, channel 1024(Overflow int32)",
+			MessageAvgSize:           1024,
+			MemoryQueueSize:          10000,
+			MemoryOverBookingPercent: 100,
+			ChannelCount:             1024,
+			WantedRequest:            "20020Mi",
+			WantedLimit:              "20020Mi",
 		},
 	}
 
@@ -65,10 +65,10 @@ func TestComputeNsqdMemoryResource(t *testing.T) {
 	for _, ut := range cases {
 		nd := &v1alpha1.Nsqd{
 			Spec: v1alpha1.NsqdSpec{
-				MessageAvgSize:        ut.MessageAvgSize,
-				MemoryOverSalePercent: ut.MemoryOverSalePercent,
-				MemoryQueueSize:       ut.MemoryQueueSize,
-				ChannelCount:          ut.ChannelCount,
+				MessageAvgSize:           ut.MessageAvgSize,
+				MemoryOverBookingPercent: ut.MemoryOverBookingPercent,
+				MemoryQueueSize:          ut.MemoryQueueSize,
+				ChannelCount:             ut.ChannelCount,
 			},
 		}
 		memRequest, memLimit := ndc.computeNsqdMemoryResource(nd)

--- a/pkg/sdk/examples/adjust_nsqd_config.go
+++ b/pkg/sdk/examples/adjust_nsqd_config.go
@@ -38,7 +38,7 @@ func main() {
 
 	var messageAvgSize int32 = 1024 // 1ki
 	var memoryQueueSize int32 = 10000
-	var memoryOverSalePercent int32 = 50
+	var memoryOverBookingPercent int32 = 50
 	var channelCount int32 = 0
 
 	common.Parse()
@@ -48,7 +48,7 @@ func main() {
 		klog.Fatalf("Init clients error: %v", err)
 	}
 
-	ndcr := types.NewNsqdConfigRequest(name, namespace, messageAvgSize, memoryQueueSize, memoryOverSalePercent, channelCount)
+	ndcr := types.NewNsqdConfigRequest(name, namespace, messageAvgSize, memoryQueueSize, memoryOverBookingPercent, channelCount)
 	ndcr.ApplyDefaults()
 	ndcr.SetSnappy(snappy)
 

--- a/pkg/sdk/examples/adjust_nsqd_memory_resource.go
+++ b/pkg/sdk/examples/adjust_nsqd_memory_resource.go
@@ -30,7 +30,7 @@ func main() {
 	var namespace string
 	var messageAvgSize int32
 	var memoryQueueSize int32
-	var memoryOverSalePercent int32
+	var memoryOverBookingPercent int32
 	var channelCount int32 = 2
 
 	common.RegisterFlags()
@@ -39,7 +39,7 @@ func main() {
 	pflag.StringVar(&namespace, "namespace", "default", "Cluster namespace")
 	pflag.Int32Var(&messageAvgSize, "message_avg_size", 1204, "Average message size")
 	pflag.Int32Var(&memoryQueueSize, "memory_queue_size", 10000, "Memory queue size")
-	pflag.Int32Var(&memoryOverSalePercent, "memory_oversale_percent", 50, "Memory oversale percent")
+	pflag.Int32Var(&memoryOverBookingPercent, "memory_overbooking_percent", 50, "Memory overbooking percent")
 	pflag.Int32Var(&channelCount, "channel_count", 1, "Channel count")
 
 	common.Parse()
@@ -49,7 +49,7 @@ func main() {
 		klog.Fatalf("Init clients error: %v", err)
 	}
 
-	ndcr := types.NewNsqdConfigRequest(name, namespace, messageAvgSize, memoryQueueSize, memoryOverSalePercent, channelCount)
+	ndcr := types.NewNsqdConfigRequest(name, namespace, messageAvgSize, memoryQueueSize, memoryOverBookingPercent, channelCount)
 	ndcr.ApplyDefaults()
 
 	// Customize wait timeout

--- a/pkg/sdk/examples/create_cluster.go
+++ b/pkg/sdk/examples/create_cluster.go
@@ -49,27 +49,27 @@ func main() {
 	var nsqAdminReplicas int32 = 2
 	var messageAvgSize int32 = 1024 // 1ki
 	var memoryQueueSize int32 = 10000
-	var memoryOverSalePercent int32 = 50
+	var memoryOverBookingPercent int32 = 50
 	var channelCount int32 = 0
 	var qpsThreshold int32 = 30000 // 30k
 	var minimum int32 = 2
 	var maximum int32 = 4
 	var enabled = false
 
-	ndcr := types.NewNsqdConfigRequest(name, namespace, messageAvgSize, memoryQueueSize, memoryOverSalePercent, channelCount)
+	ndcr := types.NewNsqdConfigRequest(name, namespace, messageAvgSize, memoryQueueSize, memoryOverBookingPercent, channelCount)
 	ndcr.ApplyDefaults()
 	// Customize nsqd config
 	//ndcr.SetMaxBodySize(1024 * 1024 * 10)
 
 	nds := v1alpha1.NsqdSpec{
-		Image:                 "dockerops123/nsqd:1.1.0",
-		Replicas:              nsqdReplicas,
-		StorageClassName:      "standard",
-		LogMappingDir:         fmt.Sprintf("/var/log/%s", name),
-		MessageAvgSize:        ndcr.GetMessageAvgSize(),
-		MemoryQueueSize:       ndcr.GetMemoryQueueSize(),
-		MemoryOverSalePercent: ndcr.GetMemoryOverSalePercent(),
-		ChannelCount:          ndcr.GetChannelCount(),
+		Image:                    "dockerops123/nsqd:1.1.0",
+		Replicas:                 nsqdReplicas,
+		StorageClassName:         "standard",
+		LogMappingDir:            fmt.Sprintf("/var/log/%s", name),
+		MessageAvgSize:           ndcr.GetMessageAvgSize(),
+		MemoryQueueSize:          ndcr.GetMemoryQueueSize(),
+		MemoryOverBookingPercent: ndcr.GetMemoryOverBookingPercent(),
+		ChannelCount:             ndcr.GetChannelCount(),
 	}
 
 	ndss := v1alpha1.NsqdScaleSpec{

--- a/pkg/sdk/v1alpha1/nsq.go
+++ b/pkg/sdk/v1alpha1/nsq.go
@@ -1040,7 +1040,7 @@ func AdjustNsqdMemoryResources(nsqClient *versioned.Clientset, ndcr *types.NsqdC
 		nsqdCopy := nsqd.DeepCopy()
 		nsqdCopy.Spec.MessageAvgSize = ndcr.GetMessageAvgSize()
 		nsqdCopy.Spec.MemoryQueueSize = ndcr.GetMemoryQueueSize()
-		nsqdCopy.Spec.MemoryOverSalePercent = ndcr.GetMemoryOverSalePercent()
+		nsqdCopy.Spec.MemoryOverBookingPercent = ndcr.GetMemoryOverBookingPercent()
 		nsqdCopy.Spec.ChannelCount = ndcr.GetChannelCount()
 
 		_, err = nsqClient.NsqV1alpha1().Nsqds(ndcr.Namespace).Update(nsqdCopy)
@@ -1068,7 +1068,7 @@ func AdjustNsqdMemoryResources(nsqClient *versioned.Clientset, ndcr *types.NsqdC
 
 		if !(nsqd.Status.MessageAvgSize == ndcr.MessageAvgSize &&
 			nsqd.Status.MemoryQueueSize == ndcr.MemoryQueueSize &&
-			nsqd.Status.MemoryOverSalePercent == ndcr.MemoryOverSalePercent &&
+			nsqd.Status.MemoryOverBookingPercent == ndcr.MemoryOverBookingPercent &&
 			nsqd.Status.ChannelCount == ndcr.ChannelCount) {
 			klog.Errorf("Waiting for nsqd %s/%s status reaches its spec", ndcr.Namespace, ndcr.Name)
 			return

--- a/pkg/sdk/v1alpha1/types/types.go
+++ b/pkg/sdk/v1alpha1/types/types.go
@@ -29,12 +29,12 @@ import (
 )
 
 type NsqdConfigRequest struct {
-	Name                  string
-	Namespace             string
-	MessageAvgSize        int32
-	MemoryQueueSize       int32
-	MemoryOverSalePercent int32
-	ChannelCount          int32
+	Name                     string
+	Namespace                string
+	MessageAvgSize           int32
+	MemoryQueueSize          int32
+	MemoryOverBookingPercent int32
+	ChannelCount             int32
 
 	DataPath               *string
 	MaxBodySize            *int32
@@ -54,20 +54,20 @@ type NsqdConfigRequest struct {
 }
 
 func NewNsqdConfigRequest(name string, namespace string, messageAvgSize int32, memoryQueueSize int32,
-	memoryOverSalePercent int32, channelCount int32) *NsqdConfigRequest {
+	memoryOverBookingPercent int32, channelCount int32) *NsqdConfigRequest {
 	return &NsqdConfigRequest{
-		Name:                  name,
-		Namespace:             namespace,
-		MessageAvgSize:        messageAvgSize,
-		MemoryQueueSize:       memoryQueueSize,
-		MemoryOverSalePercent: memoryOverSalePercent,
-		ChannelCount:          channelCount,
+		Name:                     name,
+		Namespace:                namespace,
+		MessageAvgSize:           messageAvgSize,
+		MemoryQueueSize:          memoryQueueSize,
+		MemoryOverBookingPercent: memoryOverBookingPercent,
+		ChannelCount:             channelCount,
 	}
 }
 
 func (ndcr *NsqdConfigRequest) String() string {
-	return fmt.Sprintf("Name: %v, Namespace: %v, MessageAvgSize: %v, MemoryQueueSize: %v, MemoryOverSalePercent: %v, "+
-		"ChannelCount: %v", ndcr.Name, ndcr.Namespace, ndcr.MessageAvgSize, ndcr.MemoryQueueSize, ndcr.MemoryOverSalePercent,
+	return fmt.Sprintf("Name: %v, Namespace: %v, MessageAvgSize: %v, MemoryQueueSize: %v, MemoryOverBookingPercent: %v, "+
+		"ChannelCount: %v", ndcr.Name, ndcr.Namespace, ndcr.MessageAvgSize, ndcr.MemoryQueueSize, ndcr.MemoryOverBookingPercent,
 		ndcr.ChannelCount)
 }
 
@@ -135,8 +135,8 @@ func (ndcr *NsqdConfigRequest) GetChannelCount() int32 {
 	return ndcr.ChannelCount
 }
 
-func (ndcr *NsqdConfigRequest) GetMemoryOverSalePercent() int32 {
-	return ndcr.MemoryOverSalePercent
+func (ndcr *NsqdConfigRequest) GetMemoryOverBookingPercent() int32 {
+	return ndcr.MemoryOverBookingPercent
 }
 
 func (ndcr *NsqdConfigRequest) GetMemoryQueueSize() int32 {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR refactors nsqd crd:
* adjust `replicas` minimum to 2 to make nsqd high availability.
* adjust `memoryQueueSize` to 0 to enable nsqd writing all message to disk directly.
* adjust `channelCount` to 2048 to guard against big fan-out pub/sub.
* rename `memoryOverSalePercent` to `memoryOverbookingPercent`.
