### PR TITLE
set top value for msgOverBookingPercent to 200

### DIFF
--- a/manifests/v1alpha1/nsqd.yaml
+++ b/manifests/v1alpha1/nsqd.yaml
@@ -37,7 +37,7 @@ spec:
             MemoryOverBookingPercent:
               type: integer
               minimum: 0
-              maximum: 100
+              maximum: 200
             memoryQueueSize:
               type: integer
               minimum: 0


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR sets top value for msgOverBookingPercent to 200. This makes we can request for at most 2x of the estimated memory request.
