### PR TITLE
adjust nsqdscale qpsThreshold to 15k

### DIFF
--- a/manifests/v1alpha1/test_data/nsqdscale.yaml
+++ b/manifests/v1alpha1/test_data/nsqdscale.yaml
@@ -3,7 +3,7 @@ kind: NsqdScale
 metadata:
   name: test
 spec:
-  qpsThreshold: 30000
+  qpsThreshold: 15000
   minimum: 2
   maximum: 4
   enabled: false

--- a/pkg/sdk/examples/adjust_nsqdscale.go
+++ b/pkg/sdk/examples/adjust_nsqdscale.go
@@ -37,7 +37,7 @@ func main() {
 
 	pflag.StringVar(&name, "name", "solo", "Cluster name")
 	pflag.StringVar(&namespace, "namespace", "default", "Cluster namespace")
-	pflag.Int32Var(&qpsThreshold, "qps-threshold", 40000, "Metas threshold before autoscaling")
+	pflag.Int32Var(&qpsThreshold, "qps-threshold", 15000, "Metas threshold before autoscaling")
 	pflag.Int32Var(&minimum, "minimum", 2, "Minimum nsqd instances")
 	pflag.Int32Var(&maximum, "maximum", 4, "Maximum nsqd instances")
 	pflag.BoolVar(&enabled, "enabled", false, "Whether nsqdscale is enabled")

--- a/pkg/sdk/examples/create_cluster.go
+++ b/pkg/sdk/examples/create_cluster.go
@@ -51,7 +51,7 @@ func main() {
 	var memoryQueueSize int32 = 10000
 	var memoryOverBookingPercent int32 = 50
 	var channelCount int32 = 0
-	var qpsThreshold int32 = 30000 // 30k
+	var qpsThreshold int32 = 15000 // 15k
 	var minimum int32 = 2
 	var maximum int32 = 4
 	var enabled = false


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR adjusts nsqdscale qpsThreshold to 15k to adapt for default 8 core nsqd cpu limit/request.
