### PR TITLE
adjust nsqdscale qpsThreshold ceil value to 64k

### DIFF
--- a/manifests/v1alpha1/nsqdscale.yaml
+++ b/manifests/v1alpha1/nsqdscale.yaml
@@ -23,7 +23,7 @@ spec:
             qpsThreshold:
               type: integer
               minimum: 1
-              maximum: 80000 # 80k
+              maximum: 64000 # 64k
             minimum:
               type: integer
               minimum: 2 # high availability


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
This PR adjusts nsqdscale qpsThreshold ceil value to 64k. This is under assumption that cpu request or limit for a nsqd instance is at most 32core, i.e., 2k qps per core.
